### PR TITLE
Add pre commit hook

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,3 +83,7 @@ jobs:
     - name: isort
       run: isort --check-only .
       if: always()
+
+    - name: pre-commit hook check
+      run: pre-commit run --all-files
+      if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.pyc
 __pycache__
 .ipynb_checkpoints
+*.egg-info/
+
+# IDE
+.vscode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/PyCQA/isort
+    rev: master  # stable
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+        types:
+          - python
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.790'
+    hooks:
+    - id: mypy
+      files: ibis_omniscidb/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+develop:
+	pre-commit install

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
 develop:
 	pre-commit install
+	pip install -e .

--- a/ci/setup_tests.py
+++ b/ci/setup_tests.py
@@ -144,19 +144,23 @@ def main(repo_url, schema, tables, data_directory, **params):
 
 if __name__ == '__main__':
     schema = os.path.join(BASE_PATH, 'schema.sql')
-    tables = ['functional_alltypes',
-              'diamonds',
-              'batting',
-              'awards_players',
-              'geo']
+    tables = [
+        'functional_alltypes',
+        'diamonds',
+        'batting',
+        'awards_players',
+        'geo',
+    ]
     data_directory = '/tmp/'
-    main(repo_url='https://github.com/ibis-project/testing-data',
-         schema=schema,
-         tables=tables,
-         data_directory=data_directory,
-         host='localhost',
-         port=6274,
-         user='admin',
-         password='HyperInteractive',
-         database='ibis_testing',
-         protocol='binary')
+    main(
+        repo_url='https://github.com/ibis-project/testing-data',
+        schema=schema,
+        tables=tables,
+        data_directory=data_directory,
+        host='localhost',
+        port=6274,
+        user='admin',
+        password='HyperInteractive',
+        database='ibis_testing',
+        protocol='binary',
+    )

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,8 @@ dependencies:
 - pyarrow>=0.15.0
 
 # dev
+- pip
+- pre-commit
 - pytest
 - pytest-cov
 - pytest-mock

--- a/ibis_omniscidb/compiler.py
+++ b/ibis_omniscidb/compiler.py
@@ -17,7 +17,8 @@ from .operations import _type_to_sql_string  # noqa: F401
 
 
 def build_ast(
-    expr: ibis.Expr, context: compiler.QueryContext,
+    expr: ibis.Expr,
+    context: compiler.QueryContext,
 ) -> compiler.QueryAST:
     """Build AST from given expression.
 
@@ -36,7 +37,8 @@ def build_ast(
 
 
 def _get_query(
-    expr: ibis.Expr, context: compiler.QueryContext,
+    expr: ibis.Expr,
+    context: compiler.QueryContext,
 ):
     assert context is not None, 'context is None'
     ast = build_ast(expr, context)
@@ -45,7 +47,10 @@ def _get_query(
     return query
 
 
-def to_sql(expr: ibis.Expr, context: compiler.QueryContext = None,) -> str:
+def to_sql(
+    expr: ibis.Expr,
+    context: compiler.QueryContext = None,
+) -> str:
     """Convert expression to SQL statement.
 
     Parameters

--- a/ibis_omniscidb/operations.py
+++ b/ibis_omniscidb/operations.py
@@ -13,9 +13,12 @@ import ibis.expr.rules as rlz
 import ibis.expr.types as ir
 import ibis.util as util
 from ibis import literal as L
-from ibis.backends.base_sql import (cumulative_to_window, format_window,
-                                    operation_registry,
-                                    time_range_to_range_window)
+from ibis.backends.base_sql import (
+    cumulative_to_window,
+    format_window,
+    operation_registry,
+    time_range_to_range_window,
+)
 
 from . import dtypes as omniscidb_dtypes
 from .identifiers import quote_identifier
@@ -1156,8 +1159,9 @@ _unsupported_ops = [
     ops.Union,
 ]
 
-_unsupported_ops_dict = {k: raise_unsupported_op_error
-                         for k in _unsupported_ops}
+_unsupported_ops_dict = {
+    k: raise_unsupported_op_error for k in _unsupported_ops
+}
 
 # registry
 _operation_registry = {**operation_registry}

--- a/ibis_omniscidb/tests/test_client.py
+++ b/ibis_omniscidb/tests/test_client.py
@@ -147,7 +147,10 @@ def test_drop_columns(con, test_table, column_names):
 @pytest.mark.parametrize(
     'properties',
     [
-        param({}, id='none',),
+        param(
+            {},
+            id='none',
+        ),
         param({'fragment_size': 10000000}, id='frag_size'),
         param(
             {'fragment_size': 0},
@@ -162,7 +165,8 @@ def test_drop_columns(con, test_table, column_names):
             {'max_rows': 0},
             id='max_rows0',
             marks=pytest.mark.xfail(
-                raises=Exception, reason="MAX_ROWS must be a positive number",
+                raises=Exception,
+                reason="MAX_ROWS must be a positive number",
             ),
         ),
         param(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+
+[tool.black]
+line-length = 79
+skip-string-normalization = true
+target-version = ["py37", "py38"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pymapd>=0.24
 pyarrow>=0.15.0
 
 # dev
+pre-commit
 pytest
 pytest-cov
 pytest-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,10 @@ ignore_missing_imports=True
 
 [pydocstyle]
 convention=numpy
+
+[isort]
+known_third_party = 
+ensure_newline_before_comments=true
+line_length = 79
+multi_line_output = 3
+include_trailing_comma = true


### PR DESCRIPTION
This PR:

- adds pre-commit hook for flake8, mypy, isort and black
- fixes code style using black
- adds black and isort configuration
- adds `make develop` command that prepare and install anything necessary for the development (current just install pre-commit hooks).