### PR TITLE
Adding black as dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@
 *.pyc
 __pycache__
 .ipynb_checkpoints
+
+.coverage
+coverage.xml
+*.egg-info/
+junit.xml
+
+# IDE
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,3 @@
 *.pyc
 __pycache__
 .ipynb_checkpoints
-
-.coverage
-coverage.xml
-*.egg-info/
-junit.xml
-
-# IDE
-.vscode/

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
 - pyarrow>=0.15.0
 
 # dev
+- black
 - pytest
 - pytest-cov
 - pytest-mock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 79
+skip-string-normalization = true
+target-version = ["py37", "py38"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pymapd>=0.24
 pyarrow>=0.15.0
 
 # dev
+black
 pytest
 pytest-cov
 pytest-mock


### PR DESCRIPTION
Adding black as dependency

# MOTIVATION

Black is currently used in the ibis and pandas workflow.  Also, it is a great tool for formatting code and avoid unnecessary discussions  about code styling in PRs reviews in around 99% of the time.