### PR TITLE
Add udf support

### DIFF
--- a/ci/omnisci.conf
+++ b/ci/omnisci.conf
@@ -1,0 +1,6 @@
+enable-runtime-udf = true
+enable-table-functions = true
+cpu-only = true
+enable-watchdog = false
+enable-window-functions = true
+cpu-buffer-mem-bytes = 1000000000

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - pymapd>=0.24
 - pyarrow>=0.15.0
 - numpy<1.20
+- rbc
 
 # dev
 - black

--- a/ibis_omniscidb/client.py
+++ b/ibis_omniscidb/client.py
@@ -22,6 +22,7 @@ from pymapd.dtypes import TDatumType as pymapd_dtype
 from . import ddl
 from . import dtypes as omniscidb_dtypes
 from .compiler import OmniSciDBDialect, build_ast
+from .udf import OmniSciDBUDF
 
 try:
     from cudf import DataFrame as GPUDataFrame
@@ -649,6 +650,15 @@ class OmniSciDBClient(SQLClient):
                 dbname=database,
                 protocol=protocol,
             )
+
+        # used for UDF
+        self.udf = OmniSciDBUDF(
+            host=self.con._host,
+            port=self.con._port,
+            database=self.con._dbname,
+            user=self.con._user,
+            password=self.con._password,
+        )
 
     def __del__(self):
         """Close the connection when instance is deleted."""

--- a/ibis_omniscidb/dtypes.py
+++ b/ibis_omniscidb/dtypes.py
@@ -69,3 +69,9 @@ ibis_dtypes_str_to_sql = {
     'time': 'time',
     'timestamp': 'timestamp',
 }
+
+
+# example: {dt.int64: 'int64'}
+ibis_dtypes_to_str = {}
+for sql_type, ibis_type in sql_to_ibis_dtypes.items():
+    ibis_dtypes_to_str[ibis_type] = str(ibis_type)

--- a/ibis_omniscidb/operations.py
+++ b/ibis_omniscidb/operations.py
@@ -946,6 +946,17 @@ def _window_op_one_param(name):
     return formatter
 
 
+# UDF
+
+
+def _udf(traslator, expr):
+    """UDF translation."""
+    f_name = expr._arg.func.__name__
+    args_translated = ', '.join(map(traslator.translate, expr._arg.func_args))
+
+    return '{}({})'.format(f_name, args_translated)
+
+
 # operation map
 
 _binary_infix_ops = {
@@ -1108,6 +1119,14 @@ _window_ops = {
     ops.WindowOp: _window,
 }
 
+# UDF
+_udf_ops = {
+    ops.ElementWiseVectorizedUDF: _udf,
+    ops.ReductionVectorizedUDF: _udf,
+    ops.AnalyticVectorizedUDF: _udf,
+}
+
+
 # UNSUPPORTED OPERATIONS
 _unsupported_ops = [
     # generic/aggregation
@@ -1179,5 +1198,6 @@ _operation_registry.update(_date_ops)
 _operation_registry.update(_agg_ops)
 _operation_registry.update(_geospatial_ops)
 _operation_registry.update(_window_ops)
+_operation_registry.update(_udf_ops)
 # the last update should be with unsupported ops
 _operation_registry.update(_unsupported_ops_dict)

--- a/ibis_omniscidb/tests/conftest.py
+++ b/ibis_omniscidb/tests/conftest.py
@@ -7,6 +7,8 @@ import ibis.util as util
 import pandas
 import pytest
 
+import ibis_omniscidb
+
 OMNISCIDB_HOST = os.environ.get('IBIS_TEST_OMNISCIDB_HOST', 'localhost')
 OMNISCIDB_PORT = int(os.environ.get('IBIS_TEST_OMNISCIDB_PORT', 6274))
 OMNISCIDB_USER = os.environ.get('IBIS_TEST_OMNISCIDB_USER', 'admin')
@@ -25,7 +27,7 @@ def con():
     -------
     ibis.omniscidb.OmniSciDBClient
     """
-    return ibis.omniscidb.connect(
+    return ibis_omniscidb.connect(
         protocol=OMNISCIDB_PROTOCOL,
         host=OMNISCIDB_HOST,
         port=OMNISCIDB_PORT,

--- a/ibis_omniscidb/tests/test_udf.py
+++ b/ibis_omniscidb/tests/test_udf.py
@@ -1,0 +1,88 @@
+import ibis
+import ibis.expr.datatypes as dt
+import ibis.expr.types as ir
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def add_number(con):
+    def my_add_number(left, right):
+        return left + right
+
+    for dtype in [
+        dt.float32,
+        dt.float64,
+        dt.int8,
+        dt.int16,
+        dt.int32,
+        dt.int64,
+    ]:
+        con.udf.elementwise(
+            input_type=[dtype, dtype], output_type=dtype, infer_literal=True
+        )(my_add_number)
+    return my_add_number
+
+
+@pytest.mark.parametrize(
+    'left_arg, right_arg, expected_fn',
+    [
+        pytest.param(
+            lambda t: t.float_col,
+            lambda t: t.float_col,
+            lambda df: df.float_col + df.float_col,
+            id='elementwise_float_col_plus_float_col',
+        ),
+        pytest.param(
+            lambda t: t.double_col,
+            lambda t: t.double_col,
+            lambda df: df.double_col + df.double_col,
+            id='elementwise_double_col_plus_double_col',
+        ),
+        pytest.param(
+            lambda t: t.int_col,
+            lambda t: t.int_col,
+            lambda df: df.int_col + df.int_col,
+            id='elementwise_int_col_plus_int_col',
+        ),
+        pytest.param(
+            lambda t: t.bigint_col,
+            lambda t: t.bigint_col,
+            lambda df: df.bigint_col + df.bigint_col,
+            id='elementwise_bigint_col_plus_bigint_col',
+        ),
+        pytest.param(
+            lambda t: t.int_col,
+            lambda t: 1,
+            lambda df: df.int_col + 1,
+            id='elementwise_int_col_plus_literal_int',
+        ),
+        pytest.param(
+            lambda t: t.float_col,
+            lambda t: 1.0,
+            lambda df: df.float_col + 1.0,
+            id='elementwise_float_col_plus_literal_float',
+        ),
+        pytest.param(
+            lambda t: t.bigint_col,
+            lambda t: ibis.literal(1, type='int64'),
+            lambda df: df.bigint_col + 1,
+            id='elementwise_bigint_col_plus_literal_bigint',
+        ),
+    ],
+)
+def test_elementwise_udf_number(
+    con, alltypes, add_number, left_arg, right_arg, expected_fn
+):
+    expr = add_number(left_arg(alltypes), right_arg(alltypes))
+
+    assert isinstance(expr, ir.ColumnExpr)
+    assert isinstance(expr, ir.NumericColumn)
+
+    result = expr.execute()
+
+    df = alltypes.execute()
+    expected = expected_fn(df)
+    pd.testing.assert_series_equal(
+        result, expected, check_dtype=False, check_names=False
+    )

--- a/ibis_omniscidb/udf.py
+++ b/ibis_omniscidb/udf.py
@@ -1,0 +1,298 @@
+"""OmniSciDB User Defined Function (UDF) Implementation."""
+import functools
+import types
+from typing import Callable, List, Optional
+
+import ibis
+import ibis.expr.types as ir
+from ibis.expr import datatypes as dt
+from ibis.udf import vectorized
+from rbc.omniscidb import RemoteOmnisci
+
+from .dtypes import ibis_dtypes_to_str
+
+
+def _udf_decorator(node_type, input_type, output_type, infer_literal=False):
+    # NOTE: it is used instead of the one in the core because it uses
+    #       `infer_literal` parameter.
+    def wrapper(func):
+        return UserDefinedFunction(
+            func, node_type, input_type, output_type, infer_literal
+        )
+
+    return wrapper
+
+
+def elementwise(input_type, output_type, infer_literal=False):
+    """
+    Define a UDF that operates element wise on a Pandas Series.
+
+    Parameters
+    ----------
+    input_type : List[ibis.expr.datatypes.DataType]
+        A list of the types found in :mod:`~ibis.expr.datatypes`. The
+        length of this list must match the number of arguments to the
+        function. Variadic arguments are not yet supported.
+    output_type : ibis.expr.datatypes.DataType
+        The return type of the function.
+    infer_literal : bool, default False
+        Define if literal scalar values should be infered or if this method
+        should accept explicitly just ibis literal.
+
+    Examples
+    --------
+    >>> import ibis
+    >>> import ibis.expr.datatypes as dt
+    >>> from ibis.udf.vectorized import elementwise
+    >>> @elementwise(input_type=[dt.string], output_type=dt.int64)
+    ... def my_string_length(series):
+    ...     return series.str.len() * 2
+    >>> @elementwise(input_type=[dt.string], output_type=dt.int64)
+    ... def my_string_length(series, *, times):
+    ...     return series.str.len() * times
+    """
+    # NOTE: it is used instead of the one in the core because it uses
+    #       `infer_literal` parameter.
+    return _udf_decorator(
+        vectorized.ElementWiseVectorizedUDF,
+        input_type,
+        output_type,
+        infer_literal,
+    )
+
+
+class UserDefinedFunction(vectorized.UserDefinedFunction):
+    """The UDF is used to create functions inside the backend."""
+
+    def __init__(
+        self, func, func_type, input_type, output_type, infer_literal=False
+    ):
+        super().__init__(func, func_type, input_type, output_type)
+        # Note: implement a way to use literal with UDF.
+        #       It could be pushed to the core in the future
+        self.infer_literal = infer_literal
+
+    def __call__(self, *args, **kwargs):
+        """Return a UDF expression."""
+        # kwargs cannot be part of the node object because it can contain
+        # unhashable object, e.g., list.
+        # Here, we keep the node hashable by creating a closure that contains
+        # kwargs.
+
+        @functools.wraps(self.func)
+        def func(*args):
+            return self.func(*args, **kwargs)
+
+        # Note: implement a way to use literal with UDF.
+        #       It could be pushed to the core in the future
+        if self.infer_literal:
+            new_args = []
+            for i, arg in enumerate(args):
+                if not isinstance(arg, ir.Expr):
+                    params = {}
+                    if arg is not None:
+                        params.update({'type': self.input_type[i]})
+                    arg = ibis.literal(arg, **params)
+
+                new_args.append(arg)
+            args = new_args
+
+        op = self.func_type(
+            func=func,
+            args=args,
+            input_type=self.input_type,
+            output_type=self.output_type,
+        )
+
+        return op.to_expr()
+
+
+def _create_function(name, nargs):
+    """
+    Create a function dinamically for the given name and number of arguments.
+
+    Parameters
+    ----------
+    name : str
+        name of the function
+    nargs : int
+        number of the arguments the function accept.
+
+    Returns
+    -------
+    Callable
+    """
+    # this function is used just as a template
+    def y():
+        pass
+
+    args_name = tuple('arg{}'.format(i) for i in range(nargs))
+
+    co_args = (
+        nargs,  # argcount
+        0,  # kwonlyargcount
+        0,  # nlocals
+        1,  # stacksize
+        0,  # flags
+        bytes(),  # codestring
+        (),  # constants
+        args_name,  # names
+        args_name,  # varnames
+        y.__code__.co_filename,  # filename
+        name,  # name
+        0,  # firstlineno
+        bytes(),  # lnotab
+    )
+    new_code = types.CodeType(*co_args)
+    return types.FunctionType(new_code, {}, name)
+
+
+class OmniSciDBUDF:
+    """
+    OmniSciDB UDF class.
+
+    OmniSciDB uses RBC (Remote Backend Client) to support UDF.
+    """
+
+    def __init__(
+        self,
+        host: Optional[str] = None,
+        port: Optional[int] = 6274,
+        database: Optional[str] = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+    ):
+        self.remote_backend_compiler = RemoteOmnisci(
+            host=host,
+            port=port,
+            dbname=database,
+            user=user,
+            password=password,
+        )
+
+    def _udf(
+        self,
+        udf_operation: Callable,
+        input_type: List[dt.DataType],
+        output_type: Optional[dt.DataType] = None,
+        name: Optional[str] = None,
+        infer_literal: bool = True,
+    ) -> Callable:
+        """
+        Elementwise operation for UDF.
+
+        Parameters
+        ----------
+        udf_operation : Callable
+            Used for creating UDF operation
+        input_type : List[dt.DataType]
+        output_type: dt.DataType
+        name : str
+            Used for reusing an existent UDF
+        infer_literal : bool, default True
+            Define if literal scalar values should be infered or if this method
+            should accept explicitly just ibis literal.
+
+        Returns
+        -------
+        Callable
+        """
+        if name:
+            f = _create_function(name, len(input_type))
+            return udf_operation(
+                input_type, output_type, infer_literal=infer_literal
+            )(f)
+
+        def omnisci_wrapper(f, input_type=input_type, output_type=output_type):
+            signature = '{}({})'.format(
+                ibis_dtypes_to_str[output_type],
+                ', '.join([ibis_dtypes_to_str[v] for v in input_type]),
+            )
+
+            if isinstance(f, vectorized.UserDefinedFunction):
+                f = f.func
+
+            self.remote_backend_compiler(signature)(f)
+            self.remote_backend_compiler.register()
+            return udf_operation(
+                input_type, output_type, infer_literal=infer_literal
+            )(f)
+
+        return omnisci_wrapper
+
+    def elementwise(
+        self,
+        input_type: List[dt.DataType],
+        output_type: Optional[dt.DataType] = None,
+        name: Optional[str] = None,
+        infer_literal: bool = True,
+    ) -> Callable:
+        """
+        Create an elementwise UDF operation.
+
+        Parameters
+        ----------
+        input_type : List[dt.DataType]
+        output_type: dt.DataType
+        name : str
+            Used for reusing an existent UDF
+        infer_literal : bool, default True
+            Define if literal scalar values should be infered or if this method
+            should accept explicitly just ibis literal.
+
+        Returns
+        -------
+        Callable
+        """
+        # NOTE: elementwise here is a modify version of vectorized.elementwise
+        return self._udf(
+            udf_operation=elementwise,
+            input_type=input_type,
+            output_type=output_type,
+            name=name,
+            infer_literal=infer_literal,
+        )
+
+    def reduction(
+        self,
+        input_type: List[dt.DataType],
+        output_type: Optional[dt.DataType] = None,
+        name: Optional[str] = None,
+    ) -> Callable:
+        """
+        Create a reduction UDF operation.
+
+        Parameters
+        ----------
+        input_type : List[dt.DataType]
+        output_type: dt.DataType
+        name : str
+            Used for reusing an existent UDF
+
+        Returns
+        -------
+        Callable
+        """
+        raise NotImplementedError('UDF Reduction is not implemented yet.')
+
+    def analytic(
+        self,
+        input_type: List[dt.DataType],
+        output_type: Optional[dt.DataType] = None,
+        name: Optional[str] = None,
+    ) -> Callable:
+        """
+        Create an analytic UDF operation.
+
+        Parameters
+        ----------
+        input_type : List[dt.DataType]
+        output_type: dt.DataType
+        name : str
+            Used for reusing an existent UDF
+
+        Returns
+        -------
+        Callable
+        """
+        raise NotImplementedError('UDF Analytic is not implemented yet.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ ibis-framework
 pymapd>=0.24
 pyarrow>=0.15.0
 numpy<1.20
+rbc-project
 
 # dev
 black


### PR DESCRIPTION
The work made in this PR was originally started at https://github.com/ibis-project/ibis/pull/2274

This PR:

- adds initial support for OmniSciDB UDFs
- adds support just for numeric data types (float and int) and just for elementwise operations.
- changes the omnisci service to an image that has udf resources enabled
- adds an option that allows python literals as arguments for the UDF calls
- fixes the connection used by tests

this PR depends on #10