### PR TITLE
Use conda on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,9 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: ibis-omniscidb
+        channels: conda-forge
         environment-file: environment-dev.yaml
+        mamba-version: "*"
 
     - name: start omniscidb service
       run: docker-compose --file ci/docker-compose.yaml up -d omniscidb
@@ -81,7 +83,7 @@ jobs:
         pre-commit install
 
     - name: show environment
-      run: pip list
+      run: conda list
 
     - name: pre-commit check
       run: pre-commit run --all-files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,10 @@ jobs:
       uses: actions/checkout@v1
 
     - name: setup conda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: ibis-omniscidb
-          environment-file: environment-dev.yml
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: ibis-omniscidb
+        environment-file: environment-dev.yml
 
     - name: start omniscidb service
       run: docker-compose --file ci/docker-compose.yaml up -d omniscidb

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,21 +10,29 @@ jobs:
   tests:
     name: Tests OmniSciDB
     runs-on: ubuntu-latest
+
     env:
       BACKENDS: "omniscidb"
+
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.8"]
         pymapd-version: ["stable", "dev"]
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
     steps:
     - name: checkout
       uses: actions/checkout@v1
 
-    - name: setup python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - name: setup conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: ibis-omniscidb
+          environment-file: environment-dev.yml
 
     - name: start omniscidb service
       run: docker-compose --file ci/docker-compose.yaml up -d omniscidb
@@ -35,16 +43,12 @@ jobs:
     - name: install dependencies
       run: |
         if [[ "${{ matrix.pymapd-version }}" == "dev" ]]; then
-          grep -v "pymapd" requirements.txt > requirements_no_pymapd.txt
-          python -m pip install -r requirements_no_pymapd.txt
           pip install git+https://github.com/omnisci/pymapd.git
-        else
-          python -m pip install -r requirements.txt
         fi
-        python -m pip install -e .
+        python -m pip install --no-deps -e .
 
     - name: show environment
-      run: pip list
+      run: conda list
 
     - name: setup tests
       run: python ci/setup_tests.py
@@ -55,20 +59,25 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
     steps:
 
     - name: checkout
       uses: actions/checkout@v1
 
-    - name: setup python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.7"
+    - name: setup conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: ibis-omniscidb
+          environment-file: environment-dev.yml
 
     - name: install dependencies
       run: |
-        python -m pip install -r requirements.txt
-        python -m pip install -e .
+        python -m pip install --no-deps -e .
         pre-commit install
 
     - name: show environment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,10 +70,10 @@ jobs:
       uses: actions/checkout@v1
 
     - name: setup conda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: ibis-omniscidb
-          environment-file: environment-dev.yml
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: ibis-omniscidb
+        environment-file: environment-dev.yml
 
     - name: install dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: ibis-omniscidb
-        environment-file: environment-dev.yml
+        environment-file: environment-dev.yaml
 
     - name: start omniscidb service
       run: docker-compose --file ci/docker-compose.yaml up -d omniscidb
@@ -73,7 +73,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: ibis-omniscidb
-        environment-file: environment-dev.yml
+        environment-file: environment-dev.yaml
 
     - name: install dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8"]
         pymapd-version: ["stable", "dev"]
 
     defaults:
@@ -75,7 +74,9 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: ibis-omniscidb
+        channels: conda-forge
         environment-file: environment-dev.yaml
+        mamba-version: "*"
 
     - name: install dependencies
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: master  # stable
+    rev: main  # stable
     hooks:
       - id: isort
 
@@ -10,14 +10,14 @@ repos:
       - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
       - id: flake8
         types:
           - python
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.790'
+    rev: 'v0.812'
     hooks:
     - id: mypy
       files: ibis_omniscidb/

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -1,6 +1,7 @@
 name: ibis-omniscidb-dev
 channels:
 - conda-forge
+
 dependencies:
 
 # core

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -10,6 +10,8 @@ dependencies:
 - numpy<1.20
 - rbc
 - python 3.8.*
+# TODO: sqlalchemy pinning should be removed when Ibis 2.0 is released
+- sqlalchemy<1.4
 
 # dev
 - black

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -9,6 +9,7 @@ dependencies:
 - pyarrow>=0.15.0
 - numpy<1.20
 - rbc
+- python 3.8.*
 
 # dev
 - black

--- a/ibis_omniscidb/tests/test_geo.py
+++ b/ibis_omniscidb/tests/test_geo.py
@@ -1,5 +1,3 @@
 def test_centroid(geo_table):
-    assert (
-        'POINT (25.4545454545455 26.969696969697)'
-        == geo_table.geo_polygon.centroid().execute().values[0]
-    )
+    result = geo_table.geo_polygon.centroid().execute()
+    assert 'POINT (25.4545454545455 26.969696969697)' == result.values[0].wkt


### PR DESCRIPTION
This PR updates the CI:

- use conda env on CI
- change to python 3.8 because ibis doesn't install pymapd on python 3.8, so a new verion of pymapd can be installed (because ibis is pinning an old version of pymapd).
- uses mamba instead conda for the installation (mamba takes < 3 mins, conda takes ~ 6 mins)
- fix the centroid test because now ´execute´  is returning a geopandas
- fix/update pre-commit revs

this PR prepares the way to #29 because "pip install" breaks trying to install numpy