### PR TITLE
SUPP: Remove numpy pinning and add pinning for numba

### DIFF
--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -7,20 +7,16 @@ dependencies:
 # core
 - ibis-framework  # TODO: require Ibis 2.0 when it's released
 - pandas
-- pyomnisci>=0.27.0
-- pyomniscidb>=5.5.2
+- pyomnisci >=0.27.0
+- pyomniscidb >=5.5.2
 - pyarrow
-# numpy 1.20 has conflicts with pandas and pyarrow
-# pyarrow.lib.ArrowTypeError: ('Did not pass numpy.dtype object',
-#   'Conversion failed for column salary with type float64')
-- numpy<1.20
-- rbc>=0.4.0
+- rbc >=0.4.0,<0.5
 # ibis 1.4 for python 3.7 installs pymapd, and ibis-omniscidb
 # doens't use pymapd anymore
 - python 3.8.*
 
 # TODO: sqlalchemy pinning should be removed when Ibis 2.0 is released
-- sqlalchemy<1.4
+- sqlalchemy <1.4
 
 # dev
 - black

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -6,11 +6,12 @@ dependencies:
 
 # core
 - ibis-framework  # TODO: require Ibis 2.0 when it's released
+- numba <0.54
 - pandas
 - pyomnisci >=0.27.0
 - pyomniscidb >=5.5.2
 - pyarrow
-- rbc >=0.4.0,<0.5
+- rbc >=0.4.0
 # ibis 1.4 for python 3.7 installs pymapd, and ibis-omniscidb
 # doens't use pymapd anymore
 - python 3.8.*

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,12 @@ setuptools.setup(
     python_requires='>=3.7',
     install_requires=[
         'ibis-framework',  # TODO: require ibis 2.0 when it's released
+        'numba<0.54',
         'pandas',
         'pyomnisci>=0.27.0',
         'pyomniscidb>=5.5.2',
         'pyarrow',
-        'rbc-project>=0.4.0,<0.5',
+        'rbc-project>=0.4.0',
         'sqlalchemy<1.4',  # TODO: it should be fixed by ibis 2.0
     ],
     setup_requires=['setuptools_scm'],

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         'pyomnisci>=0.27.0',
         'pyomniscidb>=5.5.2',
         'pyarrow',
-        'rbc-project>=0.4.0',
+        'rbc-project>=0.4.0,<0.5',
         'sqlalchemy<1.4',  # TODO: it should be fixed by ibis 2.0
     ],
     setup_requires=['setuptools_scm'],

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,6 @@ setuptools.setup(
         'pyarrow',
         'rbc-project>=0.4.0',
         'sqlalchemy<1.4',  # TODO: it should be fixed by ibis 2.0
-        # numpy 1.20 has conflicts with pandas and pyarrow
-        # pyarrow.lib.ArrowTypeError: ('Did not pass numpy.dtype object',
-        #   'Conversion failed for column salary with type float64')
-        'numpy<1.20',
     ],
     setup_requires=['setuptools_scm'],
     use_scm_version=True,


### PR DESCRIPTION
This PR removes the pinning for numpy that was used to resolve a conflict with pyarrow.
This PR also adds pinning for numba, because numba 0.54 has conflict with rbc

resolves #27