### PR TITLE
Remove numba pinning

### DIFF
--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -6,7 +6,7 @@ dependencies:
 
 # core
 - ibis-framework  # TODO: require Ibis 2.0 when it's released
-- numba <0.54
+- numba
 - pandas
 - pyomnisci >=0.27.0
 - pyomniscidb >=5.5.2

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     python_requires='>=3.7',
     install_requires=[
         'ibis-framework',  # TODO: require ibis 2.0 when it's released
-        'numba<0.54',
+        'numba',
         'pandas',
         'pyomnisci>=0.27.0',
         'pyomniscidb>=5.5.2',


### PR DESCRIPTION
The pinning for numba was added to avoid a conflict with RBC. 
Now RBC fixed the problem with new numba, and we can remove this pinning.