### PR TITLE
CI: Test with Ibis stable and Ibis dev in latest Python

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,9 +44,12 @@ jobs:
     - name: install dependencies
       run: |
         if [[ "${{ matrix.pyomnisci-version }}" == "dev" ]]; then
-          pip install --no-deps git+https://github.com/omnisci/pyomnisci.git
+          python -m pip install --no-deps git+https://github.com/omnisci/pyomnisci.git
+          python -m pip install git+https://github.com/ibis-project/ibis.git
+        else
+          conda install python=3.8
+          python -m pip install ibis-framework=2.0
         fi
-        python -m pip install git+https://github.com/ibis-project/ibis.git 
         python -m pip install --no-deps -e .
 
     - name: show environment

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -12,7 +12,6 @@ dependencies:
 - pyomniscidb >=5.5.2
 - pyarrow
 - rbc >=0.4.0
-- python 3.8.*
 - sqlalchemy
 
 # geo


### PR DESCRIPTION
We've got already two test builds, to test with pyomnisci or not.

The idea is to use those two builds to test:
- Latest Ibis released with Python 3.8 (oldest supported)
- Latest Python and Ibis the Ibis master