### PR TITLE
Fix deps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ $ git clone git@github.com:your_name_here/ibis-omniscidb.git
 3. Install your local copy into a virtual environment. Assuming want to use conda environment,
    this is how you set up your fork for local development:
 ```sh
-    $ conda env create -n ibis-omniscidb-dev --file environment-dev.yml
+    $ conda env create -n ibis-omniscidb --file environment-dev.yml
     $ python -m pip install -e .
     # install git pre-commit hooks
     $ pre-commit install
@@ -66,7 +66,7 @@ $ git clone git@github.com:your_name_here/ibis-omniscidb.git
 or
 
 ```sh
-    $ conda create -n ibis-omniscidb-dev python=3.7 pip
+    $ conda create -n ibis-omniscidb python=3.7 pip
     $ python -m pip install -r requirements.txt
     $ python -m pip install -e .
     # install git pre-commit hooks

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -1,4 +1,4 @@
-name: ibis-omniscidb-dev
+name: ibis-omniscidb
 channels:
 - nodefaults
 - conda-forge
@@ -6,6 +6,7 @@ channels:
 dependencies:
 
 # core
+- python
 - ibis-framework-core >=2
 - pandas
 - pyomnisci >=0.28.1

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -9,7 +9,6 @@ dependencies:
 - ibis-framework-core >=2
 - pandas
 - pyomnisci >=0.28.1
-- pyomniscidb >=5.5.2
 - pyarrow
 - rbc >=0.4.0
 

--- a/ibis_omniscidb/tests/test_operations.py
+++ b/ibis_omniscidb/tests/test_operations.py
@@ -1,7 +1,6 @@
 import re
 
 import ibis
-import numpy as np
 import pandas as pd
 import pytest
 from pytest import param
@@ -12,29 +11,32 @@ from pytest import param
     [
         param(
             lambda t: t[t, ibis.literal(1).degrees().name('n')].limit(1)['n'],
-            57.2957795130823,
+            pd.Series([57.2957795130823]),
             id='literal_degree',
         ),
         param(
             lambda t: t[t, ibis.literal(1).radians().name('n')].limit(1)['n'],
-            0.0174532925199433,
+            pd.Series([0.0174532925199433]),
             id='literal_radians',
         ),
         param(
             lambda t: t.double_col.corr(t.float_col),
-            1.000000000000113,
+            pd.Series([1.000000000000113]),
             id='double_float_correlation',
         ),
         param(
             lambda t: t.double_col.cov(t.float_col),
-            91.67005567565313,
+            pd.Series([91.67005567565313]),
             id='double_float_covariance',
         ),
     ],
 )
 def test_operations_scalar(alltypes, result_fn, expected):
     result = result_fn(alltypes).execute()
-    np.testing.assert_allclose(result, expected)
+    if not isinstance(result, pd.Series):
+        result = pd.Series([result])
+
+    pd.testing.assert_series_equal(result, expected, check_names=False)
 
 
 @pytest.mark.parametrize(
@@ -130,7 +132,7 @@ def test_arbitrary_none(alltypes, df_alltypes, result_fn, expected_fn):
     expr = result_fn(alltypes)
     result = expr.execute()
     expected = expected_fn(df_alltypes)
-    np.testing.assert_allclose(result, expected)
+    pd.testing.assert_series_equal(pd.Series([result]), pd.Series([expected]))
 
 
 @pytest.mark.parametrize(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,8 @@
 # core
 pandas
-pyomnisci>=0.27.0
-pyomniscidb>=5.5.2
+pyomnisci>=0.28.1
 pyarrow
-# numpy 1.20 has conflicts with pandas and pyarrow
-# pyarrow.lib.ArrowTypeError: ('Did not pass numpy.dtype object',
-#   'Conversion failed for column salary with type float64')
-numpy<1.20
+numpy
 rbc-project>=0.4.0
 
 # dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 pandas
 pyomnisci>=0.28.1
 pyarrow
-numpy
 rbc-project>=0.4.0
 
 # dev

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setuptools.setup(
         'ibis-framework>=2.0',
         'pandas',
         'pyomnisci>=0.28.1',
-        'pyomniscidb>=5.5.2',
         'pyarrow',
         'rbc-project>=0.4.0',
     ],


### PR DESCRIPTION
This PR aims to fix the dependency conflicts for the conda package.

In this PR:

- Removes direct dependency to numpy
- Remove direct dependency to pyomniscidb
- Change the default conda environment name (to a short name)