### PR TITLE
Change dt access from `ops.dt` to `datatypes.dt`

### DIFF
--- a/ibis_omniscidb/operations.py
+++ b/ibis_omniscidb/operations.py
@@ -804,7 +804,7 @@ def _arbitrary(translator, expr):
 class NumericTruncate(ops.NumericBinaryOp):
     """Truncates x to y decimal places."""
 
-    output_type = rlz.shape_like('left', ops.dt.float)
+    output_type = rlz.shape_like('left', dt.float)
 
 
 # GEOMETRIC
@@ -813,13 +813,13 @@ class NumericTruncate(ops.NumericBinaryOp):
 class Conv_4326_900913_X(ops.UnaryOp):
     """Converts WGS-84 latitude to WGS-84 Web Mercator x coordinate."""
 
-    output_type = rlz.shape_like('arg', ops.dt.float)
+    output_type = rlz.shape_like('arg', dt.float)
 
 
 class Conv_4326_900913_Y(ops.UnaryOp):
     """Converts WGS-84 longitude to WGS-84 Web Mercator y coordinate."""
 
-    output_type = rlz.shape_like('arg', ops.dt.float)
+    output_type = rlz.shape_like('arg', dt.float)
 
 
 # String


### PR DESCRIPTION
Last Ibis release crashed ibis-omniscidb:

```
ImportError while loading conftest '/home/guilhermeleobas/git/ibis-omniscidb/ibis_omniscidb/tests/conftest.py'.
ibis_omniscidb/__init__.py:22: in <module>
    from . import ddl
ibis_omniscidb/ddl.py:11: in <module>
    from .compiler import _type_to_sql_string, quote_identifier
ibis_omniscidb/compiler.py:13: in <module>
    from . import operations as omniscidb_ops
ibis_omniscidb/operations.py:804: in <module>
    class NumericTruncate(ops.NumericBinaryOp):
ibis_omniscidb/operations.py:807: in NumericTruncate
    output_type = rlz.shape_like('left', ops.dt.float)
E   AttributeError: module 'ibis.expr.operations' has no attribute 'dt'
```